### PR TITLE
Riallinea i Discussion template al flusso reale del Lab

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/datasets.yml
+++ b/.github/DISCUSSION_TEMPLATE/datasets.yml
@@ -11,6 +11,7 @@ body:
     id: fonte
     attributes:
       label: Fonte ufficiale
+      description: URL della pagina o del file ufficiale, per esempio una pagina dataset pubblica o una API documentata.
       placeholder: URL dataset o pagina ufficiale
     validations:
       required: true
@@ -51,4 +52,4 @@ body:
     id: criticita
     attributes:
       label: Limiti o rischi noti
-      description: Se vedi problemi, vincoli o ambiguità, segnalali qui.
+      description: Es. licenza restrittiva, anni mancanti, aggregazione troppo grossolana, dati non machine-readable.

--- a/.github/DISCUSSION_TEMPLATE/datasets.yml
+++ b/.github/DISCUSSION_TEMPLATE/datasets.yml
@@ -1,28 +1,54 @@
-title: "[Dataset] Nome dataset"
+title: "[Dataset] Nome dataset o fonte"
 body:
   - type: markdown
     attributes:
       value: |
-        Usa questo template per discutere una nuova fonte dati prima di aprire una Issue operativa.
+        Usa questo template per suggerire una nuova fonte dati o portare un dataset in intake.
+
+        Non serve avere già un progetto completo: basta una fonte buona, una possibile domanda e un motivo per cui vale la pena guardarla.
 
   - type: input
     id: fonte
     attributes:
       label: Fonte ufficiale
-      placeholder: URL dataset
+      placeholder: URL dataset o pagina ufficiale
+    validations:
+      required: true
 
   - type: textarea
     id: descrizione
     attributes:
       label: Cosa contiene?
-      description: Descrizione sintetica del dataset
+      description: Descrizione breve del dataset o della fonte.
+    validations:
+      required: true
 
   - type: textarea
-    id: struttura
+    id: perche_rileva
     attributes:
-      label: Struttura dati
+      label: Perché è rilevante?
+      description: Spiega perché questa fonte potrebbe essere utile per il Lab o per una domanda civica.
+
+  - type: textarea
+    id: domanda_potenziale
+    attributes:
+      label: Domanda civica possibile
+      description: Se questo dataset fosse utile, quale domanda concreta potremmo provare a fare?
+
+  - type: textarea
+    id: copertura
+    attributes:
+      label: Copertura e granularità
+      description: Indica periodo, livello geografico o unità di analisi se li conosci.
+
+  - type: input
+    id: formato
+    attributes:
+      label: Formato
+      placeholder: CSV, XLSX, API, ZIP, PDF, altro
 
   - type: textarea
     id: criticita
     attributes:
-      label: Limiti o rischi
+      label: Limiti o rischi noti
+      description: Se vedi problemi, vincoli o ambiguità, segnalali qui.

--- a/.github/DISCUSSION_TEMPLATE/datasets.yml
+++ b/.github/DISCUSSION_TEMPLATE/datasets.yml
@@ -7,6 +7,9 @@ body:
 
         Non serve avere già un progetto completo: basta una fonte buona, una possibile domanda e un motivo per cui vale la pena guardarla.
 
+        Se la proposta regge, il passo successivo sarà di solito una issue operativa nel repo giusto.
+        A seconda del caso, il filone potrà passare da `dataset-incubator` per la validazione tecnica oppure entrare direttamente in `dataciviclab/preanalysis`.
+
   - type: input
     id: fonte
     attributes:

--- a/.github/DISCUSSION_TEMPLATE/domande.yml
+++ b/.github/DISCUSSION_TEMPLATE/domande.yml
@@ -1,10 +1,23 @@
 title: "[Domanda] Quesito analitico"
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Usa questo template per proporre o chiarire una domanda civica, anche se il dataset non è ancora deciso del tutto.
+
   - type: textarea
     id: perche
     attributes:
       label: Perché questa domanda è rilevante?
       description: Spiega il problema pubblico o civico che vuoi capire meglio.
+    validations:
+      required: true
+
+  - type: textarea
+    id: dataset
+    attributes:
+      label: Dataset o fonti possibili
+      description: Se li conosci, indica i dataset o le fonti che potrebbero aiutare.
 
   - type: textarea
     id: metriche
@@ -22,4 +35,4 @@ body:
     id: next_step
     attributes:
       label: Se diventa lavoro concreto
-      description: Indica in quale repo dovrebbe nascere una issue operativa e quale sarebbe il primo output utile.
+      description: Indica il primo output utile o il primo passo che varrebbe la pena fare.

--- a/.github/DISCUSSION_TEMPLATE/domande.yml
+++ b/.github/DISCUSSION_TEMPLATE/domande.yml
@@ -34,5 +34,5 @@ body:
   - type: textarea
     id: next_step
     attributes:
-      label: Se diventa lavoro concreto
+      label: Primo passo concreto
       description: Indica il primo output utile o il primo passo che varrebbe la pena fare.

--- a/.github/DISCUSSION_TEMPLATE/domande.yml
+++ b/.github/DISCUSSION_TEMPLATE/domande.yml
@@ -5,6 +5,8 @@ body:
       value: |
         Usa questo template per proporre o chiarire una domanda civica, anche se il dataset non è ancora deciso del tutto.
 
+        La Discussion serve a chiarire la domanda. Se la proposta matura, il passo successivo sarà una issue operativa e poi il percorso più adatto del Lab: `dataset-incubator` oppure `dataciviclab/preanalysis`.
+
   - type: textarea
     id: perche
     attributes:

--- a/.github/DISCUSSION_TEMPLATE/metodo.yml
+++ b/.github/DISCUSSION_TEMPLATE/metodo.yml
@@ -18,6 +18,8 @@ body:
     attributes:
       label: Proposta metodologica
       description: Qual è la scelta che stai proponendo?
+    validations:
+      required: true
 
   - type: textarea
     id: alternative

--- a/.github/DISCUSSION_TEMPLATE/metodo.yml
+++ b/.github/DISCUSSION_TEMPLATE/metodo.yml
@@ -3,25 +3,30 @@ body:
   - type: markdown
     attributes:
       value: |
-        Usa questo template per discutere scelte metodologiche prima di implementarle.
+        Usa questo template per discutere scelte metodologiche prima di implementarle o promuoverle.
 
   - type: textarea
     id: contesto
     attributes:
       label: Contesto
+      description: Spiega il caso, il dataset o il filone in cui nasce il dubbio.
+    validations:
       required: true
 
   - type: textarea
     id: scelta
     attributes:
       label: Proposta metodologica
+      description: Qual è la scelta che stai proponendo?
 
   - type: textarea
     id: alternative
     attributes:
       label: Alternative valutate
+      description: Quali alternative hai considerato e perché non ti convincono del tutto?
 
   - type: textarea
     id: impatto
     attributes:
       label: Impatto su replicabilità e confronto
+      description: Spiega come questa scelta cambia confrontabilità, interpretazione o riproducibilità.

--- a/.github/DISCUSSION_TEMPLATE/presentazioni.yml
+++ b/.github/DISCUSSION_TEMPLATE/presentazioni.yml
@@ -9,7 +9,7 @@ body:
     id: bio
     attributes:
       label: Chi sei
-      description: Breve bio (2-3 righe).
+      description: Breve bio, 2-3 righe.
     validations:
       required: true
 
@@ -17,13 +17,13 @@ body:
     id: competenze
     attributes:
       label: Competenze
-      description: Dati, analisi, visualizzazione, metodo, altro.
+      description: Dati, analisi, visualizzazione, metodo, documentazione o altro.
 
   - type: textarea
     id: interessi
     attributes:
       label: Cosa ti interessa
-      description: Temi civici, dataset, progetti.
+      description: Temi civici, dataset o filoni che ti incuriosiscono di più.
 
   - type: dropdown
     id: disponibilita
@@ -37,4 +37,4 @@ body:
     id: contributo
     attributes:
       label: Come vorresti contribuire
-      description: Discussioni, analisi, doc, QA, altro.
+      description: Discussions, analisi, doc, QA, revisione, altro.

--- a/.github/DISCUSSION_TEMPLATE/presentazioni.yml
+++ b/.github/DISCUSSION_TEMPLATE/presentazioni.yml
@@ -32,6 +32,7 @@ body:
       options:
         - Occasionale
         - Continuativa
+        - Non so ancora
 
   - type: textarea
     id: contributo

--- a/.github/DISCUSSION_TEMPLATE/proposte.yml
+++ b/.github/DISCUSSION_TEMPLATE/proposte.yml
@@ -3,7 +3,9 @@ body:
   - type: markdown
     attributes:
       value: |
-        Usa questo template per proporre un **nuovo progetto** del DataCivicLab.
+        Usa questo template per proporre un nuovo filone già abbastanza maturo da essere discusso come progetto.
+
+        Se hai solo una fonte dati o una domanda iniziale, usa prima i template `Dataset` o `Domanda`.
 
   - type: textarea
     id: domanda
@@ -25,16 +27,22 @@ body:
     id: dataset
     attributes:
       label: Dataset coinvolti
-      description: Dataset - Fonte - Periodo - Livello.
+      description: Dataset, fonte, periodo, livello o unità di analisi.
+
+  - type: textarea
+    id: stato_attuale
+    attributes:
+      label: Stato attuale
+      description: Cosa esiste già? Es. intake, preanalysis privata, notebook v0, output minimo.
 
   - type: dropdown
     id: output
     attributes:
       label: Output previsto
       options:
-        - Dashboard
-        - Report
-        - Pagina pubblica
+        - Discussion / preanalysis
+        - Report / nota
+        - Dashboard / pagina pubblica
         - Altro
 
   - type: dropdown
@@ -45,13 +53,3 @@ body:
         - Bassa
         - Media
         - Alta
-
-  - type: dropdown
-    id: stato
-    attributes:
-      label: Stato
-      options:
-        - Idea
-        - In discussione
-        - Pronto per Issue
-        - In corso

--- a/.github/DISCUSSION_TEMPLATE/proposte.yml
+++ b/.github/DISCUSSION_TEMPLATE/proposte.yml
@@ -40,7 +40,6 @@ body:
     attributes:
       label: Output previsto
       options:
-        - Discussion / preanalysis
         - Report / nota
         - Dashboard / pagina pubblica
         - Altro
@@ -49,6 +48,7 @@ body:
     id: complessita
     attributes:
       label: Complessità stimata
+      description: Bassa = qualche giorno, Media = 1-2 settimane, Alta = mesi o più persone.
       options:
         - Bassa
         - Media


### PR DESCRIPTION
## Obiettivo
Closes #17
Rendere i template di GitHub Discussions piu coerenti con il flusso reale del Lab:
- dataset
- domanda
- scelta metodologica
- filone maturo
- onboarding community

## Cosa cambia

- rafforza `datasets.yml` come template per suggerire fonti dati o portare un dataset in intake
- rende `domande.yml` piu chiaro e piu utile anche quando il dataset non e ancora del tutto deciso
- ripulisce `metodo.yml` senza cambiarne il ruolo
- alleggerisce `proposte.yml`, chiarendo che non e il punto di ingresso principale per idee ancora immature
- ripulisce `presentazioni.yml`
- corregge il mojibake presente nei template

## Logica

I template ora sono piu coerenti con la distinzione tra:
- `Dataset`: ho una fonte
- `Domanda`: ho un quesito civico
- `Metodo`: ho un dubbio metodologico
- `Progetto`: il filone e gia abbastanza maturo
- `Presentazione`: onboarding community

## Cosa non fa

- non cambia le categorie di Discussions
- non modifica issue, board o automazioni
- non introduce un flusso piu pesante

## Motivo

Il Lab sta chiarendo meglio il passaggio:
`dataset -> intake -> domanda -> preanalysis -> promozione pubblica`

I template devono riflettere questo flusso, non forzare troppo presto tutto dentro un “progetto”.
