### PR TITLE
hotfix: rendere requirements.txt opzionale in python-setup action

### DIFF
--- a/actions/python-setup/action.yml
+++ b/actions/python-setup/action.yml
@@ -40,9 +40,14 @@ runs:
         python-version: ${{ inputs.python-version }}
         cache: 'pip'
 
-    - name: Install core dependencies
+    - name: Install core dependencies (if requirements.txt exists)
       shell: bash
-      run: python -m pip install -r requirements.txt
+      run: |
+        if [ -f requirements.txt ]; then
+          python -m pip install -r requirements.txt
+        else
+          echo "::notice::No requirements.txt found — skip core install"
+        fi
 
     - name: Install extra requirements files
       if: inputs.extra-requirements != ''


### PR DESCRIPTION
## Sintesi

Fix per l'action org-level mergiata in #22: alcuni repo (lab-connectors, .github stesso) non hanno `requirements.txt`, e lo step "Install core dependencies" falliva. Ora installa solo se il file esiste.

## Cosa cambia

- [x] CI

## Impatto

- [x] Nessun impatto su interfacce pubbliche

## Verifica

La CI `validate-templates` passa, ma non valida l'action a runtime. Per una validazione completa servirebbe un workflow di smoke test che usi l'action in un repo con e senza requirements.txt.

## Note

- CI attuale pass: `validate-templates` OK
- Area scoperta: nessuno smoke test runtime dell'action (non bloccante per il fix)

## Checklist PR

- [x] Perimetro stretto
