### PR TITLE
feat: reusable workflow test-audit per tutti i repo Lab

### DIFF
--- a/.github/workflows/test-audit-reusable.yml
+++ b/.github/workflows/test-audit-reusable.yml
@@ -9,6 +9,20 @@ on:
           Per ogni directory cerca {dir}/test_*.py e {dir}/**/test_*.py.
         required: true
         type: string
+      extra-packages:
+        description: >-
+          Pacchetti pip extra per python-setup.
+          Necessario per repo senza requirements.txt
+          (es. "-e ." o "-e .[dev]").
+        required: false
+        type: string
+        default: ""
+      extra-requirements:
+        description: >-
+          File requirements extra per python-setup.
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -22,6 +36,9 @@ jobs:
           fetch-depth: 0
 
       - uses: dataciviclab/.github/actions/python-setup@main
+        with:
+          extra-packages: ${{ inputs.extra-packages }}
+          extra-requirements: ${{ inputs.extra-requirements }}
 
       - name: Verify audit-test-markers CLI
         run: audit-test-markers --help
@@ -29,13 +46,10 @@ jobs:
       - name: Audit test markers
         shell: bash
         run: |
-          # Parser input test-dirs: itera ogni directory
           for dir in ${{ inputs.test-dirs }}; do
-            # Normalizza: toglie trailing slash
             dir="${dir%/}"
             echo "=== Auditing $dir/ ==="
 
-            # Trova file test modificati in questa directory
             changed=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD" \
               -- "$dir/test_*.py" "$dir/**/test_*.py" || true)
 
@@ -47,12 +61,8 @@ jobs:
             echo "Changed files:"
             echo "$changed"
 
-            # Estrae basename per audit-test-markers --files
-            files=""
-            while IFS= read -r f; do
-              base=$(basename "$f")
-              files="$files $base"
-            done <<< "$changed"
+            # Estrae basename (sort -u per gestire subdir con nomi uguali)
+            files=$(echo "$changed" | xargs -n1 basename | sort -u | tr '\n' ' ')
 
             audit-test-markers "$dir" --diff --files $files
           done

--- a/.github/workflows/test-audit-reusable.yml
+++ b/.github/workflows/test-audit-reusable.yml
@@ -61,8 +61,13 @@ jobs:
             echo "Changed files:"
             echo "$changed"
 
-            # Estrae basename (sort -u per gestire subdir con nomi uguali)
-            files=$(echo "$changed" | xargs -n1 basename | sort -u | tr '\n' ' ')
-
-            audit-test-markers "$dir" --diff --files $files
+            # Ogni file auditato nella propria directory: evita falsi
+            # positivi da basename duplicati in subdirectory diverse
+            # (es. tests/a/test_x.py e tests/b/test_x.py).
+            while IFS= read -r f; do
+              fdir=$(dirname "$f")
+              fbase=$(basename "$f")
+              echo "--- $fdir/ ($fbase) ---"
+              audit-test-markers "$fdir" --diff --files "$fbase"
+            done <<< "$changed"
           done

--- a/.github/workflows/test-audit-reusable.yml
+++ b/.github/workflows/test-audit-reusable.yml
@@ -1,0 +1,58 @@
+name: Test Marker Audit (reusable)
+on:
+  workflow_call:
+    inputs:
+      test-dirs:
+        description: >-
+          Directory da auditare separate da spazio.
+          Es. "tests" o "tests scripts/collectors".
+          Per ogni directory cerca {dir}/test_*.py e {dir}/**/test_*.py.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  audit-markers:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: dataciviclab/.github/actions/python-setup@main
+
+      - name: Verify audit-test-markers CLI
+        run: audit-test-markers --help
+
+      - name: Audit test markers
+        shell: bash
+        run: |
+          # Parser input test-dirs: itera ogni directory
+          for dir in ${{ inputs.test-dirs }}; do
+            # Normalizza: toglie trailing slash
+            dir="${dir%/}"
+            echo "=== Auditing $dir/ ==="
+
+            # Trova file test modificati in questa directory
+            changed=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD" \
+              -- "$dir/test_*.py" "$dir/**/test_*.py" || true)
+
+            if [ -z "$changed" ]; then
+              echo "No test files changed in $dir/. OK."
+              continue
+            fi
+
+            echo "Changed files:"
+            echo "$changed"
+
+            # Estrae basename per audit-test-markers --files
+            files=""
+            while IFS= read -r f; do
+              base=$(basename "$f")
+              files="$files $base"
+            done <<< "$changed"
+
+            audit-test-markers "$dir" --diff --files $files
+          done


### PR DESCRIPTION
## Sintesi

Crea `test-audit-reusable.yml` — workflow riutilizzabile per l'audit dei marker nei test, chiamabile da tutti i repo Lab.

## Cosa cambia

- [x] workflow o CI

## Impatto

- [x] Nessun impatto visibile per chi usa il repository

## Dettaglio

Aggiunge `.github/workflows/test-audit-reusable.yml` con `on: workflow_call`.

Input:
- `test-dirs` (richiesto): directory da auditare (es. `"tests"` o `"tests scripts/collectors"`)

Il workflow:
- Checkout + org-level action python-setup
- Preflight `audit-test-markers --help`
- Per ogni directory: git diff, estrazione basename, `audit-test-markers --diff --files`

Usage in un repo:
```yaml
jobs:
  audit:
    uses: dataciviclab/.github/.github/workflows/test-audit-reusable.yml@main
    with:
      test-dirs: "tests"
```

Sostituisce le 4 copie locali di `test-audit.yml` (DI, toolkit, SO, ACB).
