### PR TITLE
README: revisione — tabella 'dove andare', flusso chiaro

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # DataCivicLab GitHub Commons
 
-Questa repository raccoglie i file condivisi che definiscono l'esperienza GitHub comune di `dataciviclab`.
+Questa repository raccoglie i file condivisi che definiscono l'esperienza
+GitHub comune di `dataciviclab`.
 
-Non e' l'hub pubblico del Lab.
-E' il posto in cui teniamo ordine su GitHub.
+Non è l'hub pubblico del Lab. È il posto in cui teniamo ordine su GitHub.
 
-Qui vivono:
+## Qui vivono
 
 - community health files
 - policy comuni di collaborazione
@@ -13,7 +13,7 @@ Qui vivono:
 - profilo pubblico dell'organizzazione
 - istruzioni minime su supporto, sicurezza e canali
 
-Qui non vivono:
+## Qui non vivono
 
 - cataloghi dataset
 - roadmap del Lab
@@ -21,22 +21,27 @@ Qui non vivono:
 - documentazione tecnica del toolkit
 - bootstrap operativo dei repository dataset
 
-Per il contesto generale del Lab e l'indice dell'ecosistema, il punto di ingresso resta la repository `dataciviclab`.
-Per domande e confronto pubblico trasversale, il punto di ingresso resta [GitHub Discussions](https://github.com/orgs/dataciviclab/discussions) dell'organizzazione.
-Per seguire il lavoro in corso, il riferimento e' [Open Board](https://github.com/orgs/dataciviclab/projects/5).
-Per vedere direzione, progetti e milestone, il riferimento e' [Roadmap](https://github.com/orgs/dataciviclab/projects/2).
+## Dove andare per...
+
+| Cosa cerchi | Dove |
+|---|---|
+| Contesto generale del Lab | [`dataciviclab`](https://github.com/dataciviclab/dataciviclab) |
+| Domande e confronto pubblico | [GitHub Discussions](https://github.com/orgs/dataciviclab/discussions) |
+| Lavoro in corso | [Open Board](https://github.com/orgs/dataciviclab/projects/5) |
+| Direzione e milestone | [Roadmap](https://github.com/orgs/dataciviclab/projects/2) |
 
 ## Flusso consigliato
 
-Su GitHub cerchiamo di tenere distinti i livelli:
+Su GitHub teniamo distinti i livelli:
 
-- **Discussions** per formulare domande civiche, proposte, interpretazioni e bisogno informativo
-- **Issues** per il lavoro operativo che ne deriva
-- **PR** per le modifiche effettive a codice, documentazione o progetto
+- **Discussions** — domande civiche, proposte, interpretazioni, bisogno informativo
+- **Issues** — il lavoro operativo che ne deriva
+- **PR** — le modifiche effettive a codice, documentazione o progetto
 
-In breve:
+```
+Discussion → Issue → PR
+```
 
-`Discussion -> Issue -> PR`
-
-Non tutte le issue nascono da una discussion.
-Ma quando il punto di partenza e una domanda civica o una proposta di analisi, la discussion e il posto giusto per iniziare.
+Non tutte le issue nascono da una discussion. Ma quando il punto di partenza è
+una domanda civica o una proposta di analisi, la discussion è il posto giusto
+per iniziare.

--- a/profile/README.md
+++ b/profile/README.md
@@ -17,16 +17,29 @@ Nasce per chi vuole capire meglio il proprio territorio senza perdersi nel rumor
 Il percorso completo di un filone, dalla domanda civica all'output pubblico,
 è descritto in [dataset-project-flow.md](https://github.com/dataciviclab/dataciviclab/blob/main/docs/dataset-project-flow.md).
 
+## Dati pubblicati
+
+Il Lab pubblica dati aperti e interrogabili per tema:
+
+| Tema | Repo |
+|---|---|
+| **Spesa pubblica** | [`open-siope`](https://github.com/dataciviclab/open-siope) · [`partecipate-monitor`](https://github.com/dataciviclab/partecipate-monitor) |
+| **Lavoro pubblico** | [`open-conto-annuale`](https://github.com/dataciviclab/open-conto-annuale) |
+| **Economia e imprese** | [`rna-aiuti-stato`](https://github.com/dataciviclab/rna-aiuti-stato) · [`eurostat`](https://github.com/dataciviclab/eurostat) |
+| **Diritto e legislazione** | [`costituzione-italiana`](https://github.com/dataciviclab/costituzione-italiana) · [`italia-corpus`](https://github.com/dataciviclab/italia-corpus) · [`senato-akn`](https://github.com/dataciviclab/senato-akn) |
+| **Territorio** | [`dcl-bologna`](https://github.com/dataciviclab/dcl-bologna) |
+
+
 ## Come iniziare
 
 **Hai una domanda su un tema civico** (sanità, giustizia, finanza pubblica, ambiente)?
 Apri una [Discussion](https://github.com/dataciviclab/dataciviclab/discussions/new) con la tua domanda. Non serve saper programmare.
 
 **Conosci bene un settore** (operatore, ricercatore, giornalista)?
-Commenta una delle [analisi in corso](https://github.com/dataciviclab/dataciviclab/discussions): i caveat e il contesto di dominio valgono quanto il codice.
+Commenta una delle [discussioni](https://github.com/dataciviclab/dataciviclab/discussions): i caveat e il contesto di dominio valgono quanto il codice.
 
 **Sai lavorare con i dati** (Python, SQL, notebook)?
-Guarda le [issue con buon punto di ingresso](https://github.com/dataciviclab/dataciviclab/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) o l'[Open Board](https://github.com/orgs/dataciviclab/projects/5).
+Guarda le [issue con buon punto di ingresso](https://github.com/dataciviclab/dataciviclab/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22), l'[Open Board](https://github.com/orgs/dataciviclab/projects/5) o la [Roadmap](https://github.com/orgs/dataciviclab/projects/2).
 
 **Vuoi costruire con noi?**
 Ogni repository del Lab ha un `CONTRIBUTING.md` con le regole specifiche per contribuire.


### PR DESCRIPTION
README aggiornato secondo archetipo **A (Hub/istituzionale)** della convenzione README del Lab.

### Cosa cambia

- **Tabella "Dove andare per..."** al posto del testo libero — orientamento immediato
- Flusso `Discussion → Issue → PR` reso più leggibile
- Tono istituzionale invariato (era già buono)
- Passa da 42 a ~45 righe