### PR TITLE
ADR-001 + drift-check cross-repo + composite action python-ci

### DIFF
--- a/.github/workflows/templates.yml
+++ b/.github/workflows/templates.yml
@@ -1,4 +1,4 @@
-name: Templates
+name: Templates & Drift Check
 
 on:
   push:
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 
@@ -54,3 +54,14 @@ jobs:
           if errors:
               raise SystemExit("Template validation failed:\n" + "\n".join(errors))
           PY
+
+  drift-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Drift-check repo org vs componenti condivisi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python scripts/drift_check.py

--- a/.github/workflows/test-audit-reusable.yml
+++ b/.github/workflows/test-audit-reusable.yml
@@ -31,7 +31,7 @@ jobs:
   audit-markers:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Non è l'hub pubblico del Lab. È il posto in cui teniamo ordine su GitHub.
 - community health files
 - policy comuni di collaborazione
 - template per issue, pull request e discussions
+- decisioni architetturali sul layer GitHub ([`docs/adr`](docs/adr/))
 - profilo pubblico dell'organizzazione
 - istruzioni minime su supporto, sicurezza e canali
 

--- a/actions/python-ci/action.yml
+++ b/actions/python-ci/action.yml
@@ -20,7 +20,7 @@ description: |
         test_dir: "tests"
         pytest_args: "-q -m \"not smoke\""
         cov_module: "src"
-        cov_report: "term-missing --cov-report=xml"
+        cov_report: "term-missing xml"
         cov_threshold: "80"
 
 inputs:
@@ -55,8 +55,9 @@ inputs:
     default: "term"
   cov_threshold:
     description: >
-      Soglia per `--cov-fail-under`; vuoto = nessun gate. Usato solo se
-      cov_module è valorizzato.
+      Soglia per `--cov-fail-under`; vuoto = nessun gate. Applicata anche
+      senza cov_module (per repo che misurano coverage dal config, es.
+      source-observatory con --cov-fail-under=60).
     required: false
     default: ""
 

--- a/actions/python-ci/action.yml
+++ b/actions/python-ci/action.yml
@@ -48,8 +48,9 @@ inputs:
     default: ""
   cov_report:
     description: >
-      Report coverage (spazio-separati, es. "term-missing --cov-report=xml").
-      Usato solo se cov_module è valorizzato.
+      Nomi report coverage separati da spazio (es. "term-missing xml").
+      Ogni nome diventa `--cov-report=<nome>`. Usato solo se cov_module
+      è valorizzato.
     required: false
     default: "term"
   cov_threshold:

--- a/actions/python-ci/action.yml
+++ b/actions/python-ci/action.yml
@@ -1,0 +1,93 @@
+name: 'Python CI (org-level)'
+description: |
+  Lint (ruff) + type check (mypy) + test (pytest) come step composabili,
+  con soglia coverage opzionale. Da usare DOPO python-setup in un job
+  del repo consumer (il checkout deve essere fatto PRIMA).
+
+  Ogni repo tiene il proprio scheletro di job e aggiunge step extra dopo
+  (build, upload coverage, validazioni specifiche): la composite action
+  rende uguali solo i passi comuni, non il job intero.
+
+  Usage:
+    - uses: actions/checkout@v7
+    - uses: dataciviclab/.github/actions/python-setup@main
+      with:
+        extra-packages: -e ".[dev]"
+    - uses: dataciviclab/.github/actions/python-ci@main
+      with:
+        lint_paths: "src tests"
+        mypy_paths: "src"
+        test_dir: "tests"
+        pytest_args: "-q -m \"not smoke\""
+        cov_module: "src"
+        cov_report: "term-missing --cov-report=xml"
+        cov_threshold: "80"
+
+inputs:
+  lint_paths:
+    description: Path per `ruff check`.
+    required: true
+  mypy_paths:
+    description: Path per `mypy`; vuoto = step saltato.
+    required: false
+    default: ""
+  test_dir:
+    description: Directory dei test per pytest.
+    required: false
+    default: "tests"
+  pytest_args:
+    description: >
+      Argomenti pytest extra, passati tal quali alla shell
+      (es. "-q -m \"not smoke\"").
+    required: false
+    default: "-q"
+  cov_module:
+    description: >
+      Modulo per `--cov`; vuoto = nessuna misura coverage.
+    required: false
+    default: ""
+  cov_report:
+    description: >
+      Report coverage (spazio-separati, es. "term-missing --cov-report=xml").
+      Usato solo se cov_module è valorizzato.
+    required: false
+    default: "term"
+  cov_threshold:
+    description: >
+      Soglia per `--cov-fail-under`; vuoto = nessun gate. Usato solo se
+      cov_module è valorizzato.
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: Lint (ruff)
+      shell: bash
+      run: python -m ruff check ${{ inputs.lint_paths }}
+
+    - name: Type check (mypy)
+      if: inputs.mypy_paths != ''
+      shell: bash
+      run: python -m mypy ${{ inputs.mypy_paths }}
+
+    - name: Test (pytest)
+      shell: bash
+      env:
+        TEST_DIR: ${{ inputs.test_dir }}
+        PYTEST_ARGS: ${{ inputs.pytest_args }}
+        COV_MODULE: ${{ inputs.cov_module }}
+        COV_REPORT: ${{ inputs.cov_report }}
+        COV_THRESHOLD: ${{ inputs.cov_threshold }}
+      run: |
+        echo "::group::pytest"
+        cmd="python -m pytest $TEST_DIR $PYTEST_ARGS"
+        if [ -n "$COV_MODULE" ]; then
+          cmd="$cmd --cov=$COV_MODULE"
+          for r in $COV_REPORT; do cmd="$cmd --cov-report=$r"; done
+        fi
+        if [ -n "$COV_THRESHOLD" ]; then
+          cmd="$cmd --cov-fail-under=$COV_THRESHOLD"
+        fi
+        eval "$cmd"
+        echo "::endgroup::"

--- a/actions/python-setup/action.yml
+++ b/actions/python-setup/action.yml
@@ -35,7 +35,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@v7
       with:
         python-version: ${{ inputs.python-version }}
         cache: 'pip'

--- a/docs/adr/001-workflow-architecture.md
+++ b/docs/adr/001-workflow-architecture.md
@@ -1,0 +1,143 @@
+# ADR-001: Architettura dei workflow CI/pipeline del Lab
+
+**Status:** proposed (2026-08-16)
+
+## Contesto
+
+I workflow GitHub Actions sono distribuiti in ~15 repo e crescono con logica
+e dialetti diversi. Evidenza raccolta a 2026-08-16:
+
+- **Versioni action disallineate**: `actions/checkout@v4/v5/v6/v6.0.3/v7` e
+  `actions/setup-python@v5/v6/v6.2.0/v7` mescolati tra repo.
+- **Setup Python duplicato** con implementazioni diverse: 4 repo usano
+  `dataciviclab/.github/actions/python-setup@main`, ma `lab-connectors` e
+  `lab-dashboard` fanno `setup-python` + `pip install` inline.
+- **Stesso passo reimplementato**:
+  - blocco preflight dei `dataset.yml` in 4 repo (eurostat, open-siope,
+    open-conto-annuale, dcl-bologna) con logiche simili ma eccezioni diverse;
+  - blocco "registry → diff → draft PR" post-merge in eurostat e open-siope
+    (~40 righe ciascuno);
+  - blocco "auth GCS (JSON/base64) → gcloud" duplicato.
+- **Migrazione incompleta**: `test-audit-reusable.yml` è adottato da 3 repo,
+  ma `lab-connectors` ha ancora la copia inline.
+- **Naming ambiguo**: `smoke-weekly.yml` significa cose diverse in
+  `lab-connectors` (probe manifest GCS) e `dataset-incubator` (probe
+  raggiungibilità fonti).
+- **Soglie coverage arbitrarie**: 60/65/70/80/81 a seconda del repo.
+
+Sintomo operativo: ogni modifica a un workflow rischia di "spaccare" o di
+lasciare repo indietro (dimenticanze).
+
+Alternative considerate:
+- **Status quo** (logica in YAML, copie per-repo): non risolve drift e
+  dimenticanze; ogni fix va replicato a mano in ogni repo.
+- **Centralizzazione totale in `.github`** (workflow unico per tutti i repo):
+  i workflow diventano un monolito con troppi input; le semantiche dataset
+  (dipendenze SIOPE, codelist, bootstrap varchi) non sono esprimibili senza
+  stravolgere il modello; perde visibilità e contesto per-repo.
+- **Modello a 4 layer con delega** (scelta).
+
+## Decisione
+
+### 1. Modello a 4 layer
+
+Dipendenza in una sola direzione, top-down:
+
+```
+YAML workflow      = ORCHESTRATORE   trigger, schedule, secrets, ambiente.
+                                     Nessuna logica: chiama solo target make.
+Makefile per-repo  = INTERFACCIA     target stabili (lint/test/pipeline),
+                                     delega a comandi condivisi, zero logica.
+Package org        = IMPLEMENTAZIONE toolkit, lab-connectors: CLI versionati
+                                     e testati (toolkit run, registry build,
+                                     preflight, verify).
+.github            = COMPONENTI+REGOLE reusable workflow, composite action,
+                                     drift-check che impone il modello.
+```
+
+### 2. Regola d'oro
+
+1. **La logica non vive mai in YAML.** Passi >10 righe di shell → package org
+   o script versionato.
+2. **Stesso passo in 2+ repo → componente condiviso in `.github`**, non copia.
+3. **Il Makefile non contiene logica**, solo delega a comandi condivisi.
+4. **Locale == CI**: lo stesso comando `make` gira identico in locale e in CI;
+   il workflow chiama i target Makefile invece di replicare i comandi.
+
+### 3. Confine semantico
+
+Le semantiche dataset (dipendenze tra dataset, support seed, verify
+specifici) restano per-repo: vivono in `dataset.yml` (dati, già dichiarativi)
+e nel `pipeline.yml` orchestratore ridotto all'osso.
+
+Criterio: *se il passo è piattaforma → condiviso; se è specifico del dataset
+→ per-repo*. Le eccezioni (es. `varchi-ztl` skip, dipendenze SIOPE) restano
+nel repo come input/condizioni, non come codice duplicato.
+
+### 4. Catalogo componenti `.github` (target)
+
+| Componente | Tipo | Sostituisce |
+|---|---|---|
+| `python-setup` | composite action | setup Python (già adottato, estendere a lab-connectors, lab-dashboard) |
+| `gcs-auth` | composite action | blocco auth GCS JSON/base64 |
+| `ci-python-reusable` | reusable workflow | CI Python (ruff+mypy+pytest) |
+| `dataset-config-check-reusable` | reusable workflow | blocchi preflight dei dataset |
+| `registry-update-pr-reusable` | reusable workflow | blocco registry→diff→draft PR |
+| `test-audit-reusable` | reusable workflow | già esistente; completare migrazione lab-connectors |
+
+### 5. Versioni e pinning
+
+`checkout`, `setup-python` e dipendenze stanno dentro i componenti condivisi,
+non nei workflow per-repo → il drift versioni si risolve in un solo posto e
+dependabot si configura solo nel `.github`.
+
+I consumer restano su `@main` finché il `.github` ha review; tag semver
+(`@v1`) sono evoluzione futura se la frequenza di cambio cresce.
+
+### 6. Processo di cambiamento
+
+1. La modifica condivisa atterra in `.github` (o nel package org), mai nel
+   workflow di un singolo repo.
+2. La CI di `.github` valida: actionlint + validate template + drift-check.
+3. Il drift-check segnala i repo non migrati → issue + PR piccola per repo.
+4. I repo nuovi nascono allineati via `project-template`.
+
+### 7. Naming
+
+Disambiguare `smoke-weekly` per scopo: `probe-weekly` (raggiungibilità fonti)
+e `manifest-smoke-weekly` (catalog manifest GCS).
+
+## Conseguenze
+
+**Positive:**
+- La logica vive una sola volta, versionata e testata nei package org → meno
+  "si spacca quando cambiamo un workflow".
+- Le dimenticanze diventano visibili: il drift-check le segnala invece di
+  scoprirle per caso.
+- Locale == CI: spariscono i bug "funziona in locale ma non in CI".
+- I repo pipeline si leggono in ~15 righe di YAML + un Makefile.
+- I repo nuovi (project-template) nascono conformi.
+
+**Negative:**
+- Indirezione iniziale: per capire un workflow serve seguire la catena
+  YAML → Makefile → package.
+- Costo di migrazione dei repo esistenti (da fare uno alla volta).
+- Rischio over-engineering se si estraggono componenti per passi usati da un
+  solo repo → la regola "2+ repo" è il gate.
+- Rischio di Makefile per-repo che riproducono la stessa logica in dialetti
+  diversi → mitigato dal drift-check che verifica anche i target Makefile.
+
+## Implementazione
+
+1. [x] Questo ADR — review in `.github`
+2. [ ] `templates.yml` → drift-check (actionlint + verifica consumer dei
+       reusable + disallineamento versioni action)
+3. [ ] Migrare `lab-connectors` su `python-setup` + `test-audit-reusable`
+4. [ ] Estrarre `ci-python-reusable` e migrare i CI Python (toolkit,
+       lab-connectors, source-observatory, agent-context-builder,
+       lab-dashboard)
+5. [ ] Estrarre `dataset-config-check-reusable`, `gcs-auth`,
+       `registry-update-pr-reusable` e migrare i repo dataset (eurostat,
+       open-siope, open-conto-annuale, dcl-bologna)
+6. [ ] Disambiguare `smoke-weekly`
+7. [ ] Allineare `project-template` al modello

--- a/docs/adr/001-workflow-architecture.md
+++ b/docs/adr/001-workflow-architecture.md
@@ -141,7 +141,7 @@ e `manifest-smoke-weekly` (catalog manifest GCS).
        inline dei reusable, WARN su setup-python inline e versioni action
        fuori allowlist) — componenti condivisi allineati a canonical v7
 3. [ ] Migrare `lab-connectors` su `python-setup` + `test-audit-reusable`
-4. [~] Estrarre `python-ci` (composite action ruff+mypy+pytest) e migrare i
+4. [x] Estrarre `python-ci` (composite action ruff+mypy+pytest) e migrare i
        CI Python (toolkit, lab-connectors, source-observatory,
        agent-context-builder, lab-dashboard)
 5. [ ] Estrarre `dataset-config-check-reusable`, `gcs-auth`,

--- a/docs/adr/001-workflow-architecture.md
+++ b/docs/adr/001-workflow-architecture.md
@@ -79,11 +79,18 @@ nel repo come input/condizioni, non come codice duplicato.
 | Componente | Tipo | Sostituisce |
 |---|---|---|
 | `python-setup` | composite action | setup Python (già adottato, estendere a lab-connectors, lab-dashboard) |
+| `python-ci` | composite action | CI Python (ruff+mypy+pytest) |
 | `gcs-auth` | composite action | blocco auth GCS JSON/base64 |
-| `ci-python-reusable` | reusable workflow | CI Python (ruff+mypy+pytest) |
 | `dataset-config-check-reusable` | reusable workflow | blocchi preflight dei dataset |
 | `registry-update-pr-reusable` | reusable workflow | blocco registry→diff→draft PR |
 | `test-audit-reusable` | reusable workflow | già esistente; completare migrazione lab-connectors |
+
+**Nota su `python-ci` (composite action, non reusable workflow):** i CI Python
+dei repo differiscono per build job, upload coverage, validazioni extra e
+soglie; un job reusable rigido costringerebbe a tagli o a troppi input.
+La composite action rende uguali solo i passi comuni (lint/type/test) e lascia
+a ogni repo il proprio scheletro con step extra dopo (stesso pattern di
+`python-setup`).
 
 ### 5. Versioni e pinning
 
@@ -134,9 +141,9 @@ e `manifest-smoke-weekly` (catalog manifest GCS).
        inline dei reusable, WARN su setup-python inline e versioni action
        fuori allowlist) — componenti condivisi allineati a canonical v7
 3. [ ] Migrare `lab-connectors` su `python-setup` + `test-audit-reusable`
-4. [ ] Estrarre `ci-python-reusable` e migrare i CI Python (toolkit,
-       lab-connectors, source-observatory, agent-context-builder,
-       lab-dashboard)
+4. [~] Estrarre `python-ci` (composite action ruff+mypy+pytest) e migrare i
+       CI Python (toolkit, lab-connectors, source-observatory,
+       agent-context-builder, lab-dashboard)
 5. [ ] Estrarre `dataset-config-check-reusable`, `gcs-auth`,
        `registry-update-pr-reusable` e migrare i repo dataset (eurostat,
        open-siope, open-conto-annuale, dcl-bologna)

--- a/docs/adr/001-workflow-architecture.md
+++ b/docs/adr/001-workflow-architecture.md
@@ -130,8 +130,9 @@ e `manifest-smoke-weekly` (catalog manifest GCS).
 ## Implementazione
 
 1. [x] Questo ADR — review in `.github`
-2. [ ] `templates.yml` → drift-check (actionlint + verifica consumer dei
-       reusable + disallineamento versioni action)
+2. [x] `templates.yml` → drift-check (`scripts/drift_check.py`: ERROR su copie
+       inline dei reusable, WARN su setup-python inline e versioni action
+       fuori allowlist) — componenti condivisi allineati a canonical v7
 3. [ ] Migrare `lab-connectors` su `python-setup` + `test-audit-reusable`
 4. [ ] Estrarre `ci-python-reusable` e migrare i CI Python (toolkit,
        lab-connectors, source-observatory, agent-context-builder,

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,8 @@
+# Architecture Decision Records
+
+Decisioni architetturali sul layer GitHub dell'organizzazione
+(workflow, template, policy), in ordine cronologico.
+
+| ADR | Titolo | Data |
+|---|---|---|
+| [001](001-workflow-architecture.md) | Architettura dei workflow CI/pipeline del Lab | 2026-08-16 |

--- a/scripts/drift_check.py
+++ b/scripts/drift_check.py
@@ -15,6 +15,8 @@ Casi verificati per ogni repo in scope:
      `dataciviclab/.github/actions/python-setup`.
   C. le versioni di `actions/checkout`, `actions/setup-python` e
      `actions/upload-artifact` devono appartenere all'allowlist canonica.
+  D. i workflow che eseguono pytest inline dovrebbero usare la composite
+     action `dataciviclab/.github/actions/python-ci`.
 
 Uso (locale):
   python scripts/drift_check.py [--token $GITHUB_TOKEN]
@@ -143,6 +145,21 @@ def check_inline_setup_python(
             )
 
 
+def check_python_ci(repo: str, workflows: dict[str, str], report: Report) -> None:
+    for name, text in workflows.items():
+        if "dataciviclab/.github/actions/python-ci" in text:
+            continue  # usa già la composite action
+        # Solo workflow che sembrano un CI Python (lint + test insieme):
+        # smoke/probe/preflight che eseguono pytest da soli sono fuori scope.
+        has_lint = bool(re.search(r"ruff\s+check|ruff-action", text))
+        has_test = bool(re.search(r"\bpytest\b", text))
+        if has_lint and has_test:
+            report.warnings.append(
+                f"{repo}: {name}: lint/test inline — usa l'action org "
+                f"dataciviclab/.github/actions/python-ci"
+            )
+
+
 def check_action_versions(
     repo: str, workflows: dict[str, str], report: Report
 ) -> None:
@@ -195,6 +212,7 @@ def main() -> int:
         check_test_audit(repo, workflows, report)
         check_inline_setup_python(repo, workflows, report)
         check_action_versions(repo, workflows, report)
+        check_python_ci(repo, workflows, report)
 
     lines = render(report)
     print("\n".join(lines))

--- a/scripts/drift_check.py
+++ b/scripts/drift_check.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Drift-check cross-repo per DataCivicLab.
+
+Verifica che i repo dell'org usino i componenti condivisi del repository
+`.github` e non reintroducano copie inline o versioni disallineate.
+
+Risultati per severità:
+  ERROR — bloccano il job (exit 1): roba che va migrata al componente condiviso.
+  WARN  — disallineamenti minori, non bloccano (exit 0).
+
+Casi verificati per ogni repo in scope:
+  A. `test-audit.yml` deve referenziare il reusable (`test-audit-reusable.yml`),
+     non duplicarne il contenuto inline.
+  B. i workflow con `setup-python` inline dovrebbero usare l'action org
+     `dataciviclab/.github/actions/python-setup`.
+  C. le versioni di `actions/checkout`, `actions/setup-python` e
+     `actions/upload-artifact` devono appartenere all'allowlist canonica.
+
+Uso (locale):
+  python scripts/drift_check.py [--token $GITHUB_TOKEN]
+
+In CI (workflow `templates.yml`) il report viene anche scritto in
+`$GITHUB_STEP_SUMMARY`.
+
+Dipendenze: solo stdlib.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+
+API = "https://api.github.com"
+RAW_ACCEPT = "application/vnd.github.raw"
+
+# Repo in scope per il drift-check: core pipeline + repo dataset.
+# Aggiungere un repo quando adotta il modello del layer condiviso (ADR-001).
+REPOS = [
+    "toolkit",
+    "lab-connectors",
+    "source-observatory",
+    "dataset-incubator",
+    "data-explorer",
+    "lab-dashboard",
+    "agent-context-builder",
+    "eurostat",
+    "open-siope",
+    "open-conto-annuale",
+    "dcl-bologna",
+    "italia-corpus",
+]
+
+# Versioni canoniche delle action di piattaforma (target da standardizzare).
+# I componenti condivisi in questo repo devono allinearsi qui (ADR-001 §5).
+CANONICAL = {
+    "actions/checkout": "v7",
+    "actions/setup-python": "v7",
+    "actions/upload-artifact": "v7",
+}
+
+REUSABLE_TEST_AUDIT = "test-audit-reusable.yml"
+ORG_ACTION_PYTHON_SETUP = "dataciviclab/.github/actions/python-setup"
+
+USES_RE = re.compile(r"^\s*uses:\s*([^\s#@]+)@([^\s#]+)", re.M)
+
+
+@dataclass
+class Report:
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+
+def api_headers(token: str | None) -> dict[str, str]:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "dataciviclab-drift-check",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def api(url: str, token: str | None) -> dict | list:
+    req = urllib.request.Request(url, headers=api_headers(token))
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.load(resp)
+
+
+def fetch_workflows(repo: str, ref: str, token: str | None) -> dict[str, str]:
+    """Restituisce {filename: contenuto} dei workflow del repo."""
+    workflows: dict[str, str] = {}
+    url = f"{API}/repos/dataciviclab/{repo}/contents/.github/workflows?ref={ref}"
+    try:
+        entries = api(url, token)
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return workflows  # nessuna cartella workflow
+        raise
+    if not isinstance(entries, list):
+        return workflows
+    for entry in entries:
+        if entry["type"] != "file" or not entry["name"].endswith((".yml", ".yaml")):
+            continue
+        raw_url = f"{API}/repos/dataciviclab/{repo}/contents/{entry['path']}?ref={ref}"
+        req = urllib.request.Request(
+            raw_url, headers={**api_headers(token), "Accept": RAW_ACCEPT}
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            workflows[entry["name"]] = resp.read().decode("utf-8", "replace")
+    return workflows
+
+
+def default_branch(repo: str, token: str | None) -> str:
+    data = api(f"{API}/repos/dataciviclab/{repo}", token)
+    return str(data["default_branch"])
+
+
+def check_test_audit(repo: str, workflows: dict[str, str], report: Report) -> None:
+    for name, text in workflows.items():
+        if name != "test-audit.yml":
+            continue
+        if REUSABLE_TEST_AUDIT not in text:
+            report.errors.append(
+                f"{repo}: .github/workflows/{name} è una copia inline — "
+                f"chiama il reusable dataciviclab/.github/.github/workflows/{REUSABLE_TEST_AUDIT}"
+            )
+
+
+def check_inline_setup_python(
+    repo: str, workflows: dict[str, str], report: Report
+) -> None:
+    for name, text in workflows.items():
+        if ORG_ACTION_PYTHON_SETUP in text:
+            continue  # usa già l'action org
+        if re.search(r"actions/setup-python@", text):
+            report.warnings.append(
+                f"{repo}: {name}: setup-python inline — usa {ORG_ACTION_PYTHON_SETUP}"
+            )
+
+
+def check_action_versions(
+    repo: str, workflows: dict[str, str], report: Report
+) -> None:
+    for name, text in workflows.items():
+        for m in USES_RE.finditer(text):
+            action, version = m.group(1), m.group(2)
+            canonical = CANONICAL.get(action)
+            if canonical and version != canonical:
+                report.warnings.append(
+                    f"{repo}: {name}: {action}@{version} "
+                    f"(canonico: {action}@{canonical})"
+                )
+
+
+def render(report: Report) -> list[str]:
+    lines = ["Drift-check: repo org vs componenti condivisi (.github)", ""]
+    if not report.errors and not report.warnings:
+        lines.append("✅ Nessun disallineamento.")
+        return lines
+    if report.errors:
+        lines.append(f"❌ ERRORI ({len(report.errors)}) — bloccano il merge:")
+        lines.extend(f"  - {e}" for e in report.errors)
+        lines.append("")
+    if report.warnings:
+        lines.append(f"⚠️ WARNING ({len(report.warnings)}) — non bloccano:")
+        lines.extend(f"  - {w}" for w in report.warnings)
+        lines.append("")
+    lines.append("Riferimento: ADR-001 (docs/adr/001-workflow-architecture.md).")
+    return lines
+
+
+def main() -> int:
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("DRIFT_CHECK_TOKEN")
+    if not token:
+        print("⚠️  Nessun token: API non autenticata (rate limit basso). "
+              "Passa GITHUB_TOKEN/DRIFT_CHECK_TOKEN per risultati affidabili.")
+
+    report = Report()
+    for repo in REPOS:
+        try:
+            ref = default_branch(repo, token)
+            workflows = fetch_workflows(repo, ref, token)
+        except urllib.error.HTTPError as exc:
+            if exc.code in (403, 429):
+                print(f"[skip] {repo}: rate limit ({exc.code}) — riesegui con token")
+                break
+            raise
+        if not workflows:
+            continue
+        check_test_audit(repo, workflows, report)
+        check_inline_setup_python(repo, workflows, report)
+        check_action_versions(repo, workflows, report)
+
+    lines = render(report)
+    print("\n".join(lines))
+    step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if step_summary:
+        with open(step_summary, "a", encoding="utf-8") as fh:
+            fh.write("\n".join(["## Drift-check (ADR-001)", "", *lines, ""]))
+    return 1 if report.errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/drift_check.py
+++ b/scripts/drift_check.py
@@ -40,7 +40,7 @@ from dataclasses import dataclass, field
 API = "https://api.github.com"
 RAW_ACCEPT = "application/vnd.github.raw"
 
-# Repo in scope per il drift-check: core pipeline + repo dataset.
+# Repo in scope per il drift-check: core pipeline + repo dataset + CI Python.
 # Aggiungere un repo quando adotta il modello del layer condiviso (ADR-001).
 REPOS = [
     "toolkit",
@@ -55,7 +55,21 @@ REPOS = [
     "open-conto-annuale",
     "dcl-bologna",
     "italia-corpus",
+    "open-politica",
+    "senato-akn",
+    "rna-aiuti-stato",
+    "costituzione-italiana",
+    "data-advocacy",
+    "partecipate-monitor",
+    "project-template",
 ]
+
+# Consapevolmente fuori scope:
+#   - dataciviclab (hub: notebook validation, non CI Python)
+#   - openbdap-saldi-storico-stato (solo seed-issues, nessuna pipeline)
+#   - lab-ops, opere-pubbliche-intelligence, terzo-settore-intelligence,
+#     progetto-pilota (nessun workflow)
+#   - .github (repo del check stesso)
 
 # Versioni canoniche delle action di piattaforma (target da standardizzare).
 # I componenti condivisi in questo repo devono allinearsi qui (ADR-001 §5).


### PR DESCRIPTION
## Sintesi

Pone le fondamenta per la standardizzazione dei workflow dell'org (ADR-001):
- **ADR-001** (`docs/adr/`): modello a 4 layer (YAML orchestratore → Makefile thin → package org → componenti condivisi), regola d'oro *"la logica non vive mai in YAML"*, confine semantico e processo di cambiamento.
- **Drift-check cross-repo** (`scripts/drift_check.py` + job in `templates.yml`): verifica via API GitHub che i repo in scope usino i componenti condivisi. ERROR (bloccante) su copie inline dei reusable; WARN su setup-python inline, versioni action fuori allowlist, lint/test inline.
- **Composite action `python-ci`** (`actions/python-ci`): ruff + mypy + pytest con soglia coverage come step composabili (stesso pattern di `python-setup`).
- **Allineamento versioni**: componenti condivisi (`python-setup`, `test-audit-reusable`) e `templates.yml` portati a `actions/*@v7` (allowlist canonica).

## Contesto collegato

ADR-001 documentato in questa PR. Passi 1-4 dell'implementazione.

## Cosa cambia

- [x] Policy GitHub o template
- [x] Codice o automazioni
- [x] Documentazione

## Impatto

- [x] Policy GitHub o template
- [x] Codice o automazioni
- [ ] Pipeline dati o trasformazioni
- [ ] Contenuti o metadati di dataset

## Verifica

- `python scripts/drift_check.py` eseguito contro l'org reale: 1 ERROR atteso (lab-connectors, copia inline `test-audit`) che si chiude al merge della PR consumer corrispondente.
- Simulazione dei comandi pytest della composite action per i 5 consumer: equivalente esatto agli originali.
- YAML validati; pre-commit passati.

## Controlli

- [x] Questa PR è nel repository giusto
- [x] Ho collegato issue o discussion quando serve (ADR-001 è la reference)
- [x] Ho verificato l'impatto su documentazione, codice o dati
- [x] Ho aggiornato solo quello che era davvero necessario
- [ ] Test nuovi o modificati hanno marker — (script drift-check senza unit test: vedi note)
- [ ] Se la PR fixa un bug: N/A

## Note per chi revisiona

- **Ordine di merge consigliato**: questa PR PRIMA, poi le PR consumer (`lab-connectors`, `toolkit`, `source-observatory`, `agent-context-builder`, `lab-dashboard`), perché usano `python-ci@main` che nasce qui.
- Il job `drift-check` sarà rosso finché `lab-connectors` non migra su main (è il segnale voluto, non blocca il merge).
- Follow-up annotati: ADR → `accepted` al merge; contatore repo nel rate-limit; `dataset-incubator/lint.yml` flaggato (WARN) pur non essendo un CI Python standard; unit test per `drift_check.py` (infra pytest da aggiungere al repo).